### PR TITLE
Allow dictionary style configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ufw_rules:
     rule: allow
 ```
 
-The `ufw_rules` variable is an array of objects, with the following options from the [UFW module](http://docs.ansible.com/ansible/latest/ufw_module.html):
+The `ufw_rules` variable is an list of dictionaries, with the following options from the [UFW module](http://docs.ansible.com/ansible/latest/ufw_module.html):
 
 ```yml
 ufw_rules:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ ufw_rules:
     direction:
     log:
 ```
+You can override the `ufw_rules` variable with a dictionary variable with the name `ufw_rules_dict`, this is to allow splitting your configuration between host and group vars whilst making use of the hash merging behaviour [Reference](http://docs.ansible.com/ansible/latest/intro_configuration.html#hash-behaviour)
+```yml
+ufw_rules_dict:
+  unique_name_for_rule:
+    to_port:
+    rule:
+    proto:
+    to_ip:
+    from_port:
+    from_ip:
+    interface:
+    direction:
+    log:
+```
 
 You can specify the firewall's default policy with the `ufw_default_policy` variable, which accepts `allow`, `deny` and `reject ` as options.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ ufw_rules:
     rule: allow
   - to_port: 443
     rule: allow
+
+ufw_rules_directory: /tmp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,11 @@
     update_cache: "yes"
     cache_valid_time: 3600
 
+- name: Define rules from dictionary
+  set_fact:
+    ufw_rules: "{{ ufw_rules_dict.values() | list }}"
+  when: ufw_rules_dict is defined
+
 - name: Check if firewall rules have changed
   template:
     src: "rules.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,8 @@
   set_fact:
     ufw_rules: "{{ ufw_rules_dict.values() | list }}"
   when: ufw_rules_dict is defined
+  tags:
+    - configuration
 
 - name: Check if firewall rules have changed
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,12 @@
     - skip_ansible_lint     # When changed used to identify removed rules
     - configuration
 
+- name: Set default policy to allow
+  ufw:
+    policy: allow
+  tags:
+    - configuration
+
 - name: Apply custom firewall
   ufw:
     rule: "{{ item.rule }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Check if firewall rules have changed
   template:
     src: "rules.j2"
-    dest: "/tmp/ansible.ufw.rules"
+    dest: "{{ ufw_rules_directory }}/ansible.ufw.rules"
     mode: 0600
   register: ufw_old_rules
   tags:


### PR DESCRIPTION
If you want to split configuration for the firewall between host_vars files, group_vars files, inventory and the playbook this would allow that 